### PR TITLE
VCST-854: Add snippet version public store setting

### DIFF
--- a/src/VirtoCommerce.Hotjar.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.Hotjar.Core/ModuleConstants.cs
@@ -40,12 +40,22 @@ public static class ModuleConstants
                 IsPublic = true,
             };
 
+            public static SettingDescriptor SnippetVersion { get; } = new SettingDescriptor
+            {
+                Name = "Hotjar.SnippetVersion",
+                GroupName = "Hotjar",
+                ValueType = SettingValueType.Integer,
+                DefaultValue = 6,
+                IsPublic = true,
+            };
+
             public static IEnumerable<SettingDescriptor> AllSettings
             {
                 get
                 {
                     yield return EnableTracking;
                     yield return SiteId;
+                    yield return SnippetVersion;
                 }
             }
 
@@ -57,6 +67,7 @@ public static class ModuleConstants
             {
                 yield return General.EnableTracking;
                 yield return General.SiteId;
+                yield return General.SnippetVersion;
             }
         }
 


### PR DESCRIPTION
## Description
feat: Adds snippet version public store setting. This optional parameter that will default to the latest Hotjar Snippet version. Currently, it will default to version 6.

![image](https://github.com/VirtoCommerce/vc-module-hotjar/assets/7639413/63ced685-9191-4581-8c64-68f3ae67c7f3)


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-854
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Hotjar_3.802.0-pr-4-668e.zip
