### PR TITLE
VCST-865: Update SiteId Type from ShortText to Integer.

### DIFF
--- a/src/VirtoCommerce.Hotjar.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.Hotjar.Core/ModuleConstants.cs
@@ -35,8 +35,8 @@ public static class ModuleConstants
             {
                 Name = "Hotjar.SiteId",
                 GroupName = "Hotjar",
-                ValueType = SettingValueType.ShortText,
-                DefaultValue = string.Empty,
+                ValueType = SettingValueType.Integer,
+                DefaultValue = 0,
                 IsPublic = true,
             };
 


### PR DESCRIPTION
## Description
fix: Breaking Change. The SiteId property type has been updated from ShortText to Integer. You will need update Hotjar.SiteId in the store settings after the update. You can locate this ID at insights.hotjar.com under tracking settings.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-865
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Hotjar_3.803.0-pr-5-be8f.zip